### PR TITLE
Sidebar Styling Fixes

### DIFF
--- a/src/components/Chat/Chat.module.css
+++ b/src/components/Chat/Chat.module.css
@@ -17,7 +17,7 @@
 }
 
 .messagesWrapper {
-    display: flex;
+    /* display: flex; */ /* Removed this to fix messages display */ 
     overflow: auto;
     scrollbar-color: #c3c3c3 #1A1D21;
 }

--- a/src/components/SideBar/SideBar.js
+++ b/src/components/SideBar/SideBar.js
@@ -8,15 +8,15 @@ import OrgSettingsModal from "../Modals/OrgSettingsModal/OrgSettingsModal";
 
 import styles from "./Sidebar.module.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPlus, faCaretDown, faTrashAlt, faUser } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faCaretDown, faTrashAlt, faHashtag } from "@fortawesome/free-solid-svg-icons";
 
 class SideBar extends Component {
-    selectChannel = (event) => {
-        this.props.selectChannel(event.target.value);
+    selectChannel = (channelName) => {
+        this.props.selectChannel(channelName);
     }
 
-    selectUser = (event) => {
-        this.props.selectUser(event.target.value);
+    selectUser = (username) => {
+        this.props.selectUser(username);
     }
 
     deleteChannel = channelName => {
@@ -24,22 +24,22 @@ class SideBar extends Component {
     }
 
     render() {
-        const { sidebarChannel, unstyledButton, channelDelete, userIcon, sidebarUser, orgNameHeader, sidebar,
+        const { sidebarChannel, unstyledButton, channelDelete, sidebarUser, orgNameHeader, sidebar,
                 orgOptions, sidebarBody, sidebarSectionHeading, sidebarSectionHeadingExpand, sidebarSectionHeadingLabel, 
-                sidebarSectionHeadingRight, container, sidebarEnd, logoutBtn, sidebarItemHighlightClass, sidebarItem, orgName, loginCircle, loggedIn } = styles;
+                sidebarSectionHeadingRight, container, sidebarEnd, logoutBtn, sidebarItemHighlightClass, sidebarItem, orgName, loginCircle, loggedIn, channelIcon } = styles;
         const { org, channels, orgMembers, selectedChannel, selectedPartner, handleCreateChannelModal, handleOrgSettingsModal } = this.props;
         let isChannelsEmpty = services.utilityService.isEmpty(channels);
         let channelsDisplay = isChannelsEmpty ?
             <h2>Loading channels...</h2>
             : (Object.values(channels).map(channel => 
-                <div key={channel.name} className={`${selectedChannel && selectedChannel.name === channel.name ? sidebarItemHighlightClass : null} ${sidebarItem}`}>
-                    <button
-                        className={`${sidebarChannel} ${unstyledButton}`}
-                        type="button"
-                        value={channel.name}
-                        onClick={this.selectChannel}>
-                        {"# " + channel.name}
-                    </button>
+                <div 
+                    key={channel.name} 
+                    className={`${selectedChannel && selectedChannel.name === channel.name ? sidebarItemHighlightClass : null} ${sidebarItem}`}
+                    onClick={() => this.selectChannel(channel.name)}>
+                    <div className={channelIcon}>
+                        <FontAwesomeIcon icon={faHashtag} transform="grow-1" color="#99a59e" />
+                    </div>                    
+                    <p className={sidebarChannel}>{channel.name.toLowerCase()}</p>
                     <CanView
                         resource="channel"
                         action="delete"
@@ -61,23 +61,12 @@ class SideBar extends Component {
         let orgMembersDisplay = services.utilityService.isEmpty(orgMembers) ?
                 <h2>Loading users...</h2>
                 : (Object.values(orgMembers).map(({ username, logged_in }) => 
-                    <div key={username} className={`${selectedPartner && selectedPartner === username ? sidebarItemHighlightClass : null} ${sidebarItem}`}>
-                        <button
-                            type="button" 
-                            className={`${userIcon} ${unstyledButton}`}
-                            value={username}
-                            onClick={this.selectUser}>
-                            <FontAwesomeIcon icon={faUser} transform="grow-3" color="#c3c3c3" />
-                        </button>
-                        <button
-                            type="button"
-                            className= {`${sidebarUser} ${unstyledButton}`}
-                            value={username}
-                            onClick={this.selectUser}
-                        >
-                            {username}
-                        </button>
+                    <div 
+                        key={username} 
+                        className={`${selectedPartner && selectedPartner === username ? sidebarItemHighlightClass : null} ${sidebarItem}`}
+                        onClick={() => this.selectUser(username)}>
                         <div className={`${loginCircle} ${logged_in ? loggedIn : null}`}></div>
+                        <p className={sidebarUser}>{username}</p>                        
                     </div>
                 ))
         return (

--- a/src/components/SideBar/Sidebar.module.css
+++ b/src/components/SideBar/Sidebar.module.css
@@ -21,18 +21,18 @@
     grid-row-start: 2;
     grid-row-end:3;
     height: 87vh;
-    padding: 10px;
 }
 
 .sidebarSectionHeading {
     grid-row-start: 3;
     grid-row-end: 4;
-    padding: 9px 20px;
+    padding: 9px 0px 9px 3px;
     display: flex;
+    margin-left: 10px;
 }
 
 .sidebarSectionHeadingExpand {
-    width: 26px;
+    width: 21px;
     height: 26px;
     display: flex;
     align-items: center;
@@ -45,6 +45,7 @@
     flex: 1 1 0;
     display: block;
     text-align: left; 
+    margin-bottom: 3px;
 }
 
 .sidebarSectionHeadingRight {
@@ -61,13 +62,24 @@
 }
 
 .sidebarChannel, .sidebarUser {
-    padding: 3px 0px 3px 0px;
+    margin: 0;
     font-size: 19px;
     color: #c3c3c3;
     font-weight: 800;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+}
+
+.sidebarChannel {
+    line-height: 1.2;
+    padding-bottom: 2px;
+}
+
+.sidebarUser {
+    line-height: 0.87;
+    padding-bottom: 3px;
+    margin-left: 1px;
 }
 
 .userIcon {
@@ -86,12 +98,12 @@
 
 .sidebarItem {
     display: flex;
+    align-items: center;
     padding-left: 0px;
     position: relative;
     bottom: 12px;
     width: 100%;
-    padding: 0 auto;
-    margin-top: 10px
+    padding: 1px 9px 1px 19px;
 }
 
 .sidebarItem:hover {
@@ -131,23 +143,24 @@
     margin: 0 auto;
 }
 
+.channelIcon {
+    margin-left: 3px;
+    margin-right: 5px;
+}
+
 .loginCircle {
-    height: 10px;
-    width: 10px;
-    border: 1px solid white;
+    box-sizing: border-box;
+    height: 12px;
+    width: 12px;
+    background: #6d6d6d;
     border-radius: 50%;
-    position: relative;
-    left: 0px;
-    top: 6px;
-    padding: 5px;
     margin: 5px;
 }
 
 .loggedIn {
-    border: 1px solid white;
+    border: none;
     background: #48d248;
     box-shadow: 0px 0px 20px 1px green;
-    
 }
 
 .orgName {


### PR DESCRIPTION
- added font awesome hashtag icon to the left of channel name
- added onclick to section item div so that clicking anywhere in the div will cause a switch, rather than only on previous small button size
- replaced buttons with paragraphs for username / channel name display
- made channel name display lowercase 
- removed padding from sidebarBody so that we can have a full horizontal highlight when hovering over a sidebar item (added left padding to sidebar item to compensate and margin-left to section headings)
- added line-height to sidebarChannel and sidebarUser so that they're sized properly 
- added align-items: center to sidebarItem to take advantage of flexbox vertical alignment
- updated loginCircle styling, now takes advantage of automatic sidebarItem flexbox positioning
